### PR TITLE
Remove indicator.indicators as it's deprecated

### DIFF
--- a/batterytimepercentagecompact@sagrland.de/extension.js
+++ b/batterytimepercentagecompact@sagrland.de/extension.js
@@ -8,14 +8,14 @@ class BaTimeExtension {
       this.originalIndicator = this.aggregateMenu._power;
       this.customIndicator = new BaTime.imports.power.Indicator();
       this.aggregateMenu._indicators.replace_child(
-         this.originalIndicator.indicators,
-         this.customIndicator.indicators
+         this.originalIndicator,
+         this.customIndicator
       );
    }
    destroy() {
       this.aggregateMenu._indicators.replace_child(
-         this.customIndicator.indicators,
-         this.originalIndicator.indicators
+         this.customIndicator,
+         this.originalIndicator
       );
    }
 }


### PR DESCRIPTION
Hello

I found this message in my journal:

```log
gnome-shell[1485]: Usage of indicator.indicators is deprecated for Indicator
                   get indicators@resource:///org/gnome/shell/ui/panelMenu.js:214:25
                   destroy@/home/user/.local/share/gnome-shell/extensions/batterytimepercentagecompact@sagrland.de/extension.js:17:1
                   disable@/home/user/.local/share/gnome-shell/extensions/batterytimepercentagecompact@sagrland.de/extension.js:30:11
                   _callExtensionDisable@resource:///org/gnome/shell/ui/extensionSystem.js:122:32
                   _onEnabledExtensionsChanged/<@resource:///org/gnome/shell/ui/extensionSystem.js:532:45
                   _onEnabledExtensionsChanged@resource:///org/gnome/shell/ui/extensionSystem.js:532:24
                   createCheckedMethod/<@resource:///org/gnome/gjs/modules/core/overrides/Gio.js:533:46
                   disableExtension@resource:///org/gnome/shell/ui/extensionSystem.js:223:29
                   DisableExtension@resource:///org/gnome/shell/ui/shellDBus.js:451:38
                   _handleMethodCall@resource:///org/gnome/gjs/modules/core/overrides/Gio.js:310:38
                   _wrapJSObject/<@resource:///org/gnome/gjs/modules/core/overrides/Gio.js:387:34
```

It's already fixed upstream: https://github.com/mzur/gnome-shell-batime/commit/e842589bb22f565db1b89daa4c1c11039eeaba96

I just applied the same fix to this fork. The message disappeared from the journal.